### PR TITLE
Ensure file urls are fully qualified

### DIFF
--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -161,7 +161,7 @@ class _IndexCache:
         for child in body:
             if child.tag == "a":
                 name = child.text
-                url = child.attrib["href"]
+                url = urllib_parse.urljoin(self.index_url, child.attrib["href"])
                 attributes = {k: v for k, v in child.attrib.items() if k != "href"}
                 fragment = urllib_parse.urlsplit(url).fragment
                 self._packages[package_name][name] = File(


### PR DESCRIPTION
In [_cache.py](https://github.com/EpicWink/proxpi/blob/02f6d0ff0dc96eb7e1f2d50f0c884e2d01f7c354/src/proxpi/_cache.py#L223), the download link only pulls the href attribute of the element. Some self-hosted PyPI instances (like my company's) host the packages on the same server so these links are relative. This leads to errors farther down the line where it is assumed that the URLs are absolute when they aren't.

This patch ensures all download URLs are always fully qualified to avoid issues down the line.

