### PR TITLE
Fixed NotFound raised for exclusively extra index packages

### DIFF
--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -626,7 +626,7 @@ class Cache:
             for file in extra_files:
                 if file.name not in {f.name for f in files}:
                     files.append(file)
-        if exc:
+        if not files and exc:
             raise exc
         return files
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -201,7 +201,7 @@ def test_list(server):
         assert href == f"{text}/"
 
 
-@pytest.mark.parametrize("project", ["proxpi", "numpy"])
+@pytest.mark.parametrize("project", ["proxpi", "numpy", "scipy"])
 def test_package(server, project):
     """Test getting package files."""
     project_url = f"{server}/index/{project}/"


### PR DESCRIPTION
The typing and style refactor in commit e59a1566035a0ea3b55942ba182db1f7a89d240b appears to have broken extra indexes. The logic changed from "raise existing error if no files found" to "raise error if exception occurred." While this is now type-safe, it introduced a bug for packages that only exist in the extra indexes. When attempting to pull a package from an extra index that doesn't exist in the primary index, the `exc` variable will always be a `NotFound` exception and will be raised at the end of the function, regardless of files discovered in the extra caches.

I've updated the logic to require that there are no files _and_ the exception occurred in order to raise `exc`.