### PR TITLE
add PROXPI_GIVEUP_TIME env variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ change in a package index.
 * `PROXPI_BINARY_FILE_MIME_TYPE=1`: force file-response content-type to
   `"application/octet-stream"` instead of letting Flask guess it. This may be needed
   if your package installer (eg Poetry) mishandles responses with declared encoding.
-* `PROXPI_GIVEUP_TIME`: time (in seconds) before `proxpi` will redirect to the
+* `PROXPI_DOWNLOAD_TIMEOUT`: time (in seconds) before `proxpi` will redirect to the
   proxied index server for file downloads instead of waiting for the download,
   default: 0.9
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ change in a package index.
 * `PROXPI_BINARY_FILE_MIME_TYPE=1`: force file-response content-type to
   `"application/octet-stream"` instead of letting Flask guess it. This may be needed
   if your package installer (eg Poetry) mishandles responses with declared encoding.
+* `PROXPI_GIVEUP_TIME`: it's the time that Proxpi should wait for a package to be downloaded from pypi before redirecting user to pypi.org.
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ change in a package index.
 * `PROXPI_BINARY_FILE_MIME_TYPE=1`: force file-response content-type to
   `"application/octet-stream"` instead of letting Flask guess it. This may be needed
   if your package installer (eg Poetry) mishandles responses with declared encoding.
-* `PROXPI_GIVEUP_TIME`: it's the time that Proxpi should wait for a package to be downloaded from pypi before redirecting user to pypi.org.
+* `PROXPI_GIVEUP_TIME`: time (in seconds) before `proxpi` will redirect to the
+  proxied index server for file downloads instead of waiting for the download,
+  default: 0.9
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -662,7 +662,13 @@ class _FileCache:
         logger.debug(f"Finished downloading '{url_masked}'")
 
     def _wait_for_existing_download(self, url: str) -> bool:
-        """Wait ``self.download_timeout`` seconds for existing download."""
+        """Wait for existing download, if any.
+
+        Returns:
+            whether the wait is given up (ie if time-out was reached or
+                exception was encountered)
+        """
+
         file = self._files.get(url)
         if isinstance(file, Thread):
             try:

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -34,7 +34,7 @@ EXTRA_INDEX_TTLS = [
 
 CACHE_SIZE = int(os.environ.get("PROXPI_CACHE_SIZE", 5368709120))
 CACHE_DIR = os.environ.get("PROXPI_CACHE_DIR")
-GIVEUP_TIME = float(os.environ.get("PROXPI_GIVEUP_TIME", 0.9))
+DOWNLOAD_TIMEOUT = float(os.environ.get("PROXPI_DOWNLOAD_TIMEOUT", 0.9))
 
 logger = logging.getLogger(__name__)
 _name_normalise_re = re.compile("[-_.]+")
@@ -766,7 +766,7 @@ class Cache:
 
         root_cache = cls._index_cache_cls(INDEX_URL, INDEX_TTL, session)
         file_cache = cls._file_cache_cls(
-            CACHE_SIZE, CACHE_DIR, GIVEUP_TIME, session
+            CACHE_SIZE, CACHE_DIR, DOWNLOAD_TIMEOUT, session
         )
         if len(EXTRA_INDEX_URLS) != len(EXTRA_INDEX_TTLS):
             raise RuntimeError(

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -34,6 +34,7 @@ EXTRA_INDEX_TTLS = [
 
 CACHE_SIZE = int(os.environ.get("PROXPI_CACHE_SIZE", 5368709120))
 CACHE_DIR = os.environ.get("PROXPI_CACHE_DIR")
+GIVEUP_TIME = int(os.environ.get("PROXPI_GIVEUP_TIME", 0.9))
 
 logger = logging.getLogger(__name__)
 _name_normalise_re = re.compile("[-_.]+")
@@ -654,11 +655,11 @@ class _FileCache:
         logger.debug(f"Finished downloading '{url_masked}'")
 
     def _wait_for_existing_download(self, url: str) -> bool:
-        """Wait 0.9s for existing download."""
+        """Wait PROXPI_GIVEUP_TIME seconds for existing download."""
         file = self._files.get(url)
         if isinstance(file, Thread):
             try:
-                file.join(0.9)
+                file.join(GIVEUP_TIME)
             except Exception as e:
                 if file.exc and file == self._files[url]:
                     self._files.pop(url, None)

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -34,7 +34,7 @@ EXTRA_INDEX_TTLS = [
 
 CACHE_SIZE = int(os.environ.get("PROXPI_CACHE_SIZE", 5368709120))
 CACHE_DIR = os.environ.get("PROXPI_CACHE_DIR")
-GIVEUP_TIME = int(os.environ.get("PROXPI_GIVEUP_TIME", 0.9))
+GIVEUP_TIME = float(os.environ.get("PROXPI_GIVEUP_TIME", 0.9))
 
 logger = logging.getLogger(__name__)
 _name_normalise_re = re.compile("[-_.]+")


### PR DESCRIPTION
it's the time that should wait for a package to be downloaded from pypi before redirecting user to pypi.org.

I needed this variable to prevent redirecting to pypi.org for large packages (more than 500MB).