### PR TITLE
Feature/adding option to allow unsafe indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ change in a package index.
 * `PROXPI_BINARY_FILE_MIME_TYPE=1`: force file-response content-type to
   `"application/octet-stream"` instead of letting Flask guess it. This may be needed
   if your package installer (eg Poetry) mishandles responses with declared encoding.
-* `PROXPI_ALLOW_UNSAFE=1` allow access to all remote indexes without validating the
-  certificate.
+* `PROXPI_DISABLE_INDEX_SSL_VERIFICATION=1`: don't verify any index SSL certificates
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ change in a package index.
 * `PROXPI_BINARY_FILE_MIME_TYPE=1`: force file-response content-type to
   `"application/octet-stream"` instead of letting Flask guess it. This may be needed
   if your package installer (eg Poetry) mishandles responses with declared encoding.
+* `PROXPI_ALLOW_UNSAFE=1` allow access to all remote indexes without validating the
+  certificate.
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -26,6 +26,7 @@ INDEX_URL = os.environ.get("PROXPI_INDEX_URL", "https://pypi.org/simple/")
 EXTRA_INDEX_URLS = [
     s for s in os.environ.get("PROXPI_EXTRA_INDEX_URLS", "").strip().split(",") if s
 ]
+ALLOW_UNSAFE = os.environ.get("PROXPI_ALLOW_UNSAFE", "0") == "1"
 
 INDEX_TTL = int(os.environ.get("PROXPI_INDEX_TTL", 1800))
 EXTRA_INDEX_TTLS = [
@@ -336,6 +337,7 @@ class _IndexCache:
         self.index_url = index_url
         self.ttl = ttl
         self.session = session or requests.Session()
+        self.session.verify = ALLOW_UNSAFE
         self._index_t = None
         self._index_lock = threading.Lock()
         self._package_locks = _Locks()
@@ -591,6 +593,7 @@ class _FileCache:
         self.max_size = max_size
         self.cache_dir = os.path.abspath(cache_dir or tempfile.mkdtemp())
         self.session = session or requests.Session()
+        self.session.verify = ALLOW_UNSAFE
         self._cache_dir_provided = cache_dir
         self._files = {}
         self._evict_lock = threading.Lock()
@@ -746,6 +749,7 @@ class Cache:
     def from_config(cls):
         """Create cache from configuration."""
         session = requests.Session()
+        session.verify = ALLOW_UNSAFE
         proxpi_version = get_proxpi_version()
         if proxpi_version:
             session.headers["User-Agent"] = f"proxpi/{proxpi_version}"

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -337,7 +337,7 @@ class _IndexCache:
         self.index_url = index_url
         self.ttl = ttl
         self.session = session or requests.Session()
-        self.session.verify = ALLOW_UNSAFE
+        self.session.verify = not ALLOW_UNSAFE
         self._index_t = None
         self._index_lock = threading.Lock()
         self._package_locks = _Locks()
@@ -593,7 +593,7 @@ class _FileCache:
         self.max_size = max_size
         self.cache_dir = os.path.abspath(cache_dir or tempfile.mkdtemp())
         self.session = session or requests.Session()
-        self.session.verify = ALLOW_UNSAFE
+        self.session.verify = not ALLOW_UNSAFE
         self._cache_dir_provided = cache_dir
         self._files = {}
         self._evict_lock = threading.Lock()
@@ -749,7 +749,7 @@ class Cache:
     def from_config(cls):
         """Create cache from configuration."""
         session = requests.Session()
-        session.verify = ALLOW_UNSAFE
+        session.verify = not ALLOW_UNSAFE
         proxpi_version = get_proxpi_version()
         if proxpi_version:
             session.headers["User-Agent"] = f"proxpi/{proxpi_version}"

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -26,7 +26,9 @@ INDEX_URL = os.environ.get("PROXPI_INDEX_URL", "https://pypi.org/simple/")
 EXTRA_INDEX_URLS = [
     s for s in os.environ.get("PROXPI_EXTRA_INDEX_URLS", "").strip().split(",") if s
 ]
-ALLOW_UNSAFE = os.environ.get("PROXPI_ALLOW_UNSAFE", "0") == "1"
+DISABLE_INDEX_SSL_VERIFICATION = os.environ.get(
+    "PROXPI_DISABLE_INDEX_SSL_VERIFICATION", ""
+) not in ("", "0", "no", "off", "false")
 
 INDEX_TTL = int(os.environ.get("PROXPI_INDEX_TTL", 1800))
 EXTRA_INDEX_TTLS = [
@@ -747,7 +749,7 @@ class Cache:
     def from_config(cls):
         """Create cache from configuration."""
         session = requests.Session()
-        session.verify = not ALLOW_UNSAFE
+        session.verify = not DISABLE_INDEX_SSL_VERIFICATION
         proxpi_version = get_proxpi_version()
         if proxpi_version:
             session.headers["User-Agent"] = f"proxpi/{proxpi_version}"

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -337,7 +337,6 @@ class _IndexCache:
         self.index_url = index_url
         self.ttl = ttl
         self.session = session or requests.Session()
-        self.session.verify = not ALLOW_UNSAFE
         self._index_t = None
         self._index_lock = threading.Lock()
         self._package_locks = _Locks()
@@ -593,7 +592,6 @@ class _FileCache:
         self.max_size = max_size
         self.cache_dir = os.path.abspath(cache_dir or tempfile.mkdtemp())
         self.session = session or requests.Session()
-        self.session.verify = not ALLOW_UNSAFE
         self._cache_dir_provided = cache_dir
         self._files = {}
         self._evict_lock = threading.Lock()


### PR DESCRIPTION
This change adds the option to allow access to unsafe url's. This is useful for private networks that do not have valid ssl certificates (or those that need to be manually installed, but you run it from a docker, so the installed certificates are not detected)