### PR TITLE
Add requests connect and read timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ change in a package index.
 * `PROXPI_DOWNLOAD_TIMEOUT`: time (in seconds) before `proxpi` will redirect to the
   proxied index server for file downloads instead of waiting for the download,
   default: 0.9
+* `PROXPI_CONNECT_TIMEOUT`: time (in seconds) `proxpi` will wait for a socket to
+  connect to the index server before `requests` raises a `ConnectTimeout` error
+  to prevent indefinite blocking
+  default: 5
+* `PROXPI_READ_TIMEOUT`: time (in seconds) `proxpi` will wait for a chunk of data 
+  from the index server before `requests` raises a ReadTimeout error to prevent
+  indefinite blocking
+  default: 5
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -113,13 +113,13 @@ def server(mock_root_index, mock_extra_index):
     root_patch = mock.patch.object(
         proxpi.server.cache,
         "root_cache",
-        proxpi.server.cache._index_cache_cls(f"{mock_root_index}/", 15, session),
+        proxpi.server.cache._index_cache_cls(f"{mock_root_index}/", 15, session=session),
     )
     # noinspection PyProtectedMember
     extras_patch = mock.patch.object(
         proxpi.server.cache,
         "extra_caches",
-        [proxpi.server.cache._index_cache_cls(f"{mock_extra_index}/", 10, session)],
+        [proxpi.server.cache._index_cache_cls(f"{mock_extra_index}/", 10, session=session)],
     )
     with root_patch, extras_patch:
         yield from _utils.make_server(proxpi_server.app)


### PR DESCRIPTION
I've run into issues a few times where packets are lost connecting to an index server and `requests` waits for the response indefinitely, blocking the current thread. Eventually all the threads become blocked and the whole server hangs. This PR adds environment variable configuration for [`requests` connect and read timeouts](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts).

Please let me know if there are any changes you'd like me to make to the implementation. I could see it going a few different ways like:

- only having a single timeout for connect & read
- building a wrapper around the `requests.Session` to dry up the implementation between the `_IndexCache` and `_FileCache`

Issue: N/A
