### PR TITLE
Ensure HTTP auth persists throughout session

### DIFF
--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -67,11 +67,22 @@ class Thread(threading.Thread):
             self.exc = e
 
 
-def make_server(app: "flask.Flask") -> t.Generator[str, None, None]:
+def make_server(
+    app: "flask.Flask",
+    auth: t.Tuple[t.Optional[str], t.Optional[str]] = (None, None),
+) -> t.Generator[str, None, None]:
     server = werkzeug.serving.make_server(host="localhost", port=0, app=app)
     thread = Thread(target=server.serve_forever, args=(0.05,))
     thread.start()
-    yield f"http://localhost:{server.port}"
+    username, password = auth
+    creds = ""
+    if username is not None:
+        creds = username
+        if password is not None:
+            creds += f":{password}"
+        creds += "@"
+
+    yield f"http://{creds}localhost:{server.port}"
     server.shutdown()
     thread.join(timeout=0.1)
     if thread.exc:


### PR DESCRIPTION
Trying to use HTTP-basic authentication with GitLab, but was running into an error

```
2023-11-03 22:20:57 [    INFO] proxpi._cache: Listing packages in index 'https://__token__:****@gitlab.domain.com/api/v4/groups/123/-/packages/pypi/simple'
2023-11-03 22:20:57 [   ERROR] proxpi: Exception on /index/my-package/ [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 2525, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1822, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/usr/local/lib/python3.10/site-packages/proxpi/server.py", line 172, in list_files
    files = cache.list_files(package_name)
  File "/usr/local/lib/python3.10/site-packages/proxpi/_cache.py", line 817, in list_files
    extra_files = cache.list_files(package_name)
  File "/usr/local/lib/python3.10/site-packages/proxpi/_cache.py", line 462, in list_files
    self._list_files(package_name)
  File "/usr/local/lib/python3.10/site-packages/proxpi/_cache.py", line 425, in _list_files
    response.raise_for_status()
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://gitlab.domain.com/api/v4/groups/123/-/packages/pypi/simple/my-package
```

It seemed like the credentials were not being cached properly throughout the session. I dug around a bit, and adding this got things working for my private repo(s) as well as public PyPi.