### PR TITLE
fix content links

### DIFF
--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -377,7 +377,7 @@ class _IndexCache:
             response_data = response.json()
             for project in response_data["projects"]:
                 name_normalised = _name_normalise_re.sub("-", project["name"]).lower()
-                self._index[name_normalised] = f"{name_normalised}/"
+                self._index[name_normalised] = name_normalised
             logger.debug(
                 f"Finished listing packages in index '{self._index_url_masked}'",
             )

--- a/src/proxpi/server.py
+++ b/src/proxpi/server.py
@@ -165,7 +165,7 @@ def list_packages():
     return _compress(response)
 
 
-@app.route("/index/<package_name>/")
+@app.route("/index/<string:package_name>", strict_slashes=False)
 def list_files(package_name: str):
     """List all files for a project."""
     try:
@@ -195,7 +195,7 @@ def list_files(package_name: str):
     return _compress(response)
 
 
-@app.route("/index/<package_name>/<file_name>")
+@app.route("/index/<string:package_name>/<string:file_name>")
 def get_file(package_name: str, file_name: str):
     """Download a file."""
     try:
@@ -216,8 +216,8 @@ def invalidate_list():
     return {"status": "success", "data": None}
 
 
-@app.route("/cache/<package_name>", methods=["DELETE"])
-def invalidate_package(package_name):
+@app.route("/cache/<string:package_name>", methods=["DELETE"])
+def invalidate_package(package_name: str):
     """Invalidate project file list cache."""
     cache.invalidate_project(package_name)
     return {"status": "success", "data": None}

--- a/src/proxpi/templates/files.html
+++ b/src/proxpi/templates/files.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     {%- for file in files %}
-    <a href="{{ file.name }}{% if file.fragment %}#{{ file.fragment }}{% endif %}"
+    <a href="{{ url_for('get_file', package_name=package_name, file_name=file.name, _anchor=file.fragment|default(none)) }}"
         {%- for key, value in file.attributes.items() %} {{ key }}="{{ value }}"{% endfor -%}
     >{{ file.name }}</a><br />
     {%- endfor %}

--- a/src/proxpi/templates/packages.html
+++ b/src/proxpi/templates/packages.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     {%- for package in package_names %}
-    <a href="{{ package }}/">{{ package }}</a><br />
+    <a href="{{ url_for('list_files', package_name=package) }}">{{ package }}</a><br />
     {%- endfor %}
 </body>
 </html>

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -160,7 +160,7 @@ def test_list(server, accept, index_json_response, clear_index_cache):
     assert parser.anchors
     for text, attributes in parser.anchors:
         (href,) = (v for k, v in attributes if k == "href")
-        assert href == f"{text}/"
+        assert pathlib.Path(href).name == text
 
 
 @pytest.mark.parametrize("accept", [
@@ -218,10 +218,10 @@ def test_package(server, project, accept, index_json_response, clear_projects_ca
         href_parsed: urllib_parse.SplitResult = urllib_parse.urlsplit(href)
         href_parsed_stripped = href_parsed._replace(fragment="")
         href_stripped = href_parsed_stripped.geturl()
-        assert href_stripped == text
+        assert pathlib.Path(href_stripped).name == text
 
         if href_parsed.fragment and not file_downloaded:
-            file_response = requests.get(urllib_parse.urljoin(project_url, href))
+            file_response = requests.get(urllib_parse.urljoin(server, href))
             file_response.raise_for_status()
 
             for part in href_parsed.fragment.split(","):


### PR DESCRIPTION
Hello!

Turns out poetry could not parse relative links. It is obvious bug in poetry but I think it's faster and somehow better to generate absolute paths.