### PR TITLE
Add exclude newer flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Support [simple repository API](https://packaging.python.org/en/latest/specifications/simple-repository-api/)
   v1.1, both as producer and consumer (ie project versions, and file size and
   upload-time)
+* Exclude recently-uploaded files with `PROXPI_EXCLUDE_NEWER` (and
+  `PROXPI_EXCLUDE_NEWER_UNKNOWN` for files with unknown upload-time)
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ change in a package index.
 * `PROXPI_LOGGING_LEVEL`: Python
   [logging level](https://docs.python.org/3/library/logging.html#levels); default:
   `INFO`
+* `PROXPI_EXCLUDE_NEWER`: exclude files uploaded within this many seconds of the
+  current time, default: none (disabled)
+* `PROXPI_EXCLUDE_NEWER_UNKNOWN`: whether to exclude files with an unknown upload-time
+  when `PROXPI_EXCLUDE_NEWER` is set, `exclude` or `include`, default: `exclude`. Note:
+  Files served via the HTML API always have an unknown upload-time
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ change in a package index.
   `INFO`
 * `PROXPI_EXCLUDE_NEWER`: exclude files uploaded within this many seconds of the
   current time, default: none (disabled)
-* `PROXPI_EXCLUDE_NEWER_UNKNOWN`: whether to exclude files with an unknown upload-time
-  when `PROXPI_EXCLUDE_NEWER` is set, `exclude` or `include`, default: `exclude`. Note:
-  Files served via the HTML API always have an unknown upload-time
+* `PROXPI_EXCLUDE_NEWER_UNKNOWN=1`: also exclude files with an unknown upload-time when
+  `PROXPI_EXCLUDE_NEWER` is set, instead of always keeping them. Note: files served via
+  the HTML API always have an unknown upload-time
 
 ### Considerations with CI
 `proxpi` was designed with three goals (particularly for continuous integration (CI)):

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -7,6 +7,7 @@ import time
 import shutil
 import typing as t
 import logging
+import datetime
 import tempfile
 import warnings
 import functools
@@ -53,10 +54,25 @@ READ_TIMEOUT = (
     else None
 )
 
+EXCLUDE_NEWER = (
+    datetime.timedelta(seconds=float(os.environ.get("PROXPI_EXCLUDE_NEWER")))
+    if os.environ.get("PROXPI_EXCLUDE_NEWER") is not None
+    else None
+)
+
+EXCLUDE_NEWER_UNKNOWN = os.environ.get("PROXPI_EXCLUDE_NEWER_UNKNOWN", "exclude")
+
 logger = logging.getLogger(__name__)
 _name_normalise_re = re.compile("[-_.]+")
 _hostname_normalise_pattern = re.compile(r"[^a-z0-9]+")
 _time_offset = time.time()
+
+
+def _is_excluded_newer(upload_time: t.Optional[str]) -> bool:
+    if upload_time is None:
+        return EXCLUDE_NEWER_UNKNOWN != "include"
+    uploaded_time = datetime.datetime.fromisoformat(upload_time.replace("Z", "+00:00"))
+    return uploaded_time > datetime.datetime.now(datetime.timezone.utc) - EXCLUDE_NEWER
 
 
 def _now() -> float:
@@ -623,13 +639,23 @@ class _IndexCache:
             == "application/vnd.pypi.simple.v1+json"
         ):
             response_data = response.json()
+            excluded_a_file = False
             for file_data in response_data["files"]:
                 file = FileFromJSON.from_json_response(file_data, response.request.url)
+                if EXCLUDE_NEWER is not None and _is_excluded_newer(file.upload_time):
+                    excluded_a_file = True
+                    continue
                 package.files[file.name] = file
             self._packages[package_name] = package
-            if _parse_version(
-                (response_data.get("meta") or {}).get("api-version") or "1.0",
-            ) >= (1, 1):
+            if (
+                _parse_version(
+                    (response_data.get("meta") or {}).get("api-version") or "1.0",
+                )
+                >= (1, 1)
+                and not excluded_a_file
+            ):
+                # upstream's version list can't be trusted once files have been
+                # excluded, since it isn't filtered to match
                 package.versions = response_data.get("versions")
             logger.debug(f"Finished listing files in package '{package_name}'")
             return
@@ -639,6 +665,10 @@ class _IndexCache:
         for _, child in lxml.etree.iterparse(stream, tag="a", html=True):
             if True:  # minimise Git diff
                 file = FileFromHTML.from_html_element(child, response.request.url)
+
+                if EXCLUDE_NEWER is not None and _is_excluded_newer(file.upload_time):
+                    continue
+
                 package.files[file.name] = file
         self._packages[package_name] = package
         logger.debug(f"Finished listing files in package '{package_name}'")

--- a/src/proxpi/_cache.py
+++ b/src/proxpi/_cache.py
@@ -60,7 +60,9 @@ EXCLUDE_NEWER = (
     else None
 )
 
-EXCLUDE_NEWER_UNKNOWN = os.environ.get("PROXPI_EXCLUDE_NEWER_UNKNOWN", "exclude")
+EXCLUDE_NEWER_UNKNOWN = os.environ.get(
+    "PROXPI_EXCLUDE_NEWER_UNKNOWN", ""
+).lower() not in ("","0","no","off","false")
 
 logger = logging.getLogger(__name__)
 _name_normalise_re = re.compile("[-_.]+")
@@ -70,7 +72,7 @@ _time_offset = time.time()
 
 def _is_excluded_newer(upload_time: t.Optional[str]) -> bool:
     if upload_time is None:
-        return EXCLUDE_NEWER_UNKNOWN != "include"
+        return EXCLUDE_NEWER_UNKNOWN
     uploaded_time = datetime.datetime.fromisoformat(upload_time.replace("Z", "+00:00"))
     return uploaded_time > datetime.datetime.now(datetime.timezone.utc) - EXCLUDE_NEWER
 
@@ -639,23 +641,13 @@ class _IndexCache:
             == "application/vnd.pypi.simple.v1+json"
         ):
             response_data = response.json()
-            excluded_a_file = False
             for file_data in response_data["files"]:
                 file = FileFromJSON.from_json_response(file_data, response.request.url)
-                if EXCLUDE_NEWER is not None and _is_excluded_newer(file.upload_time):
-                    excluded_a_file = True
-                    continue
                 package.files[file.name] = file
             self._packages[package_name] = package
-            if (
-                _parse_version(
-                    (response_data.get("meta") or {}).get("api-version") or "1.0",
-                )
-                >= (1, 1)
-                and not excluded_a_file
-            ):
-                # upstream's version list can't be trusted once files have been
-                # excluded, since it isn't filtered to match
+            if _parse_version(
+                (response_data.get("meta") or {}).get("api-version") or "1.0",
+            ) >= (1, 1):
                 package.versions = response_data.get("versions")
             logger.debug(f"Finished listing files in package '{package_name}'")
             return
@@ -665,10 +657,6 @@ class _IndexCache:
         for _, child in lxml.etree.iterparse(stream, tag="a", html=True):
             if True:  # minimise Git diff
                 file = FileFromHTML.from_html_element(child, response.request.url)
-
-                if EXCLUDE_NEWER is not None and _is_excluded_newer(file.upload_time):
-                    continue
-
                 package.files[file.name] = file
         self._packages[package_name] = package
         logger.debug(f"Finished listing files in package '{package_name}'")
@@ -1099,6 +1087,19 @@ class Cache:
 
         if not files and exc:
             raise exc
+
+        if EXCLUDE_NEWER is not None:
+            excluded_names = [
+                name
+                for name, file in files.items()
+                if _is_excluded_newer(file.upload_time)
+            ]
+            if excluded_names:
+                for name in excluded_names:
+                    del files[name]
+                # upstream's version list can't be trusted once files have been
+                # excluded, since it isn't filtered to match
+                versions = None
 
         return list(files.values()), (list(versions) if versions is not None else None)
 

--- a/tests/data/indexes/root/proxpi/index.json
+++ b/tests/data/indexes/root/proxpi/index.json
@@ -7,6 +7,7 @@
       },
       "requires-python": ">=3.7",
       "size": 128,
+      "upload-time": "2099-01-01T00:00:00Z",
       "url": "proxpi-1.1.0-py3-none-any.whl"
     },
     {
@@ -16,6 +17,7 @@
       },
       "requires-python": ">=3.7",
       "size": 85,
+      "upload-time": "2020-01-01T00:00:00Z",
       "url": "proxpi-1.1.0.tar.gz"
     },
     {

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,37 @@
+"""Test ``proxpi`` cache internals."""
+
+import datetime
+from unittest import mock
+
+import pytest
+
+from proxpi import _cache
+
+
+@pytest.mark.parametrize(("upload_time", "expected"), [
+    pytest.param("2020-01-01T00:00:00Z", False, id="old_file"),
+    pytest.param(None, True, id="unknown_excluded_by_default"),
+])  # fmt: skip
+def test_is_excluded_newer(upload_time, expected):
+    """Test excluding files by upload time against a fixed window."""
+    with mock.patch.object(_cache, "EXCLUDE_NEWER", datetime.timedelta(hours=1)):
+        assert _cache._is_excluded_newer(upload_time) is expected
+
+
+def test_is_excluded_newer_recent_file():
+    """Test a recently-uploaded file is excluded."""
+    upload_time = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    with mock.patch.object(_cache, "EXCLUDE_NEWER", datetime.timedelta(hours=1)):
+        assert _cache._is_excluded_newer(upload_time) is True
+
+
+def test_is_excluded_newer_unknown_included():
+    """Test files with unknown upload time are kept when configured to."""
+    exclude_newer_patch = mock.patch.object(
+        _cache, "EXCLUDE_NEWER", datetime.timedelta(hours=1)
+    )
+    unknown_patch = mock.patch.object(_cache, "EXCLUDE_NEWER_UNKNOWN", "include")
+    with exclude_newer_patch, unknown_patch:
+        assert _cache._is_excluded_newer(None) is False

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,7 +10,7 @@ from proxpi import _cache
 
 @pytest.mark.parametrize(("upload_time", "expected"), [
     pytest.param("2020-01-01T00:00:00Z", False, id="old_file"),
-    pytest.param(None, True, id="unknown_excluded_by_default"),
+    pytest.param(None, False, id="unknown_included_by_default"),
 ])  # fmt: skip
 def test_is_excluded_newer(upload_time, expected):
     """Test excluding files by upload time against a fixed window."""
@@ -27,11 +27,11 @@ def test_is_excluded_newer_recent_file():
         assert _cache._is_excluded_newer(upload_time) is True
 
 
-def test_is_excluded_newer_unknown_included():
-    """Test files with unknown upload time are kept when configured to."""
+def test_is_excluded_newer_unknown_excluded():
+    """Test files with unknown upload time are excluded when configured to."""
     exclude_newer_patch = mock.patch.object(
         _cache, "EXCLUDE_NEWER", datetime.timedelta(hours=1)
     )
-    unknown_patch = mock.patch.object(_cache, "EXCLUDE_NEWER_UNKNOWN", "include")
+    unknown_patch = mock.patch.object(_cache, "EXCLUDE_NEWER_UNKNOWN", True)
     with exclude_newer_patch, unknown_patch:
-        assert _cache._is_excluded_newer(None) is False
+        assert _cache._is_excluded_newer(None) is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -428,9 +428,9 @@ def test_package_json(
 
 
 @pytest.mark.parametrize(("unknown_setting", "expected_filenames"), [
-    pytest.param("exclude", {"proxpi-1.1.0.tar.gz"}, id="unknown_excluded"),
+    pytest.param(True, {"proxpi-1.1.0.tar.gz"}, id="unknown_excluded"),
     pytest.param(
-        "include",
+        False,
         {"proxpi-1.1.0.tar.gz", "proxpi-1.0.0-py3-none-any.whl", "proxpi-1.0.0.tar.gz"},
         id="unknown_included",
     ),
@@ -475,8 +475,8 @@ def test_package_json_exclude_newer_drops_versions(server, clear_projects_cache)
     assert "versions" not in response.json()
 
 
-def test_package_html_exclude_newer_unknown(server, clear_projects_cache):
-    """Test excluding files by upload time with the HTML API (all unknown)."""
+def test_package_html_exclude_newer_unknown_default(server, clear_projects_cache):
+    """Test files with unknown upload time are kept by default (HTML API)."""
     exclude_newer_patch = mock.patch.object(
         proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
     )
@@ -485,7 +485,51 @@ def test_package_html_exclude_newer_unknown(server, clear_projects_cache):
             response = requests.get(f"{server}/index/proxpi/", timeout=5)
     assert response.status_code == 200
     parser = _utils.IndexParser.from_text(response.text)
+    assert parser.anchors
+
+
+def test_package_html_exclude_newer_unknown_excluded(server, clear_projects_cache):
+    """Test excluding files by upload time with the HTML API (all unknown)."""
+    exclude_newer_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
+    )
+    unknown_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER_UNKNOWN", True
+    )
+    with exclude_newer_patch, unknown_patch:
+        with set_mock_index_response_is_json(_ResponseType.html):
+            response = requests.get(f"{server}/index/proxpi/", timeout=5)
+    assert response.status_code == 200
+    parser = _utils.IndexParser.from_text(response.text)
     assert not parser.anchors
+
+
+def test_package_json_exclude_newer_not_cached(server, clear_projects_cache):
+    """Test exclusion isn't baked into the index cache, so it can't go stale."""
+    with set_mock_index_response_is_json(_ResponseType.json):
+        response = requests.get(
+            f"{server}/index/proxpi/",
+            headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+            timeout=5,
+        )
+        assert response.status_code == 200
+        filenames = {f["filename"] for f in response.json()["files"]}
+        assert "proxpi-1.1.0-py3-none-any.whl" in filenames
+
+        # same warm cache, but exclusion is now switched on: the file must
+        # disappear immediately, without needing a fresh upstream fetch
+        exclude_newer_patch = mock.patch.object(
+            proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
+        )
+        with exclude_newer_patch:
+            response = requests.get(
+                f"{server}/index/proxpi/",
+                headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+                timeout=5,
+            )
+    assert response.status_code == 200
+    filenames = {f["filename"] for f in response.json()["files"]}
+    assert "proxpi-1.1.0-py3-none-any.whl" not in filenames
 
 
 def test_package_unknown_accept(server):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,6 +4,7 @@ import enum
 import hashlib
 import logging
 import pathlib
+import datetime
 import warnings
 import posixpath
 import contextlib
@@ -173,6 +174,9 @@ def clear_index_cache(server):
 
 @pytest.fixture
 def clear_projects_cache(server):
+    for project_name in proxpi.server.cache.list_projects():
+        proxpi.server.cache.invalidate_project(project_name)
+    yield
     for project_name in proxpi.server.cache.list_projects():
         proxpi.server.cache.invalidate_project(project_name)
 
@@ -421,6 +425,67 @@ def test_package_json(
             assert set(response_data["versions"]) == {"1.9.0"}
     else:
         raise RuntimeError(f"Unexpected project: {project}")
+
+
+@pytest.mark.parametrize(("unknown_setting", "expected_filenames"), [
+    pytest.param("exclude", {"proxpi-1.1.0.tar.gz"}, id="unknown_excluded"),
+    pytest.param(
+        "include",
+        {"proxpi-1.1.0.tar.gz", "proxpi-1.0.0-py3-none-any.whl", "proxpi-1.0.0.tar.gz"},
+        id="unknown_included",
+    ),
+])  # fmt: skip
+def test_package_json_exclude_newer(
+    server, clear_projects_cache, unknown_setting, expected_filenames
+):
+    """Test excluding files by upload time with the JSON API."""
+    exclude_newer_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
+    )
+    unknown_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER_UNKNOWN", unknown_setting
+    )
+    with exclude_newer_patch, unknown_patch:
+        with set_mock_index_response_is_json(_ResponseType.json):
+            response = requests.get(
+                f"{server}/index/proxpi/",
+                headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+                timeout=5,
+            )
+    assert response.status_code == 200
+    filenames = {f["filename"] for f in response.json()["files"]}
+    # future upload-time is always excluded, regardless of unknown setting
+    assert "proxpi-1.1.0-py3-none-any.whl" not in filenames
+    assert filenames == expected_filenames
+
+
+def test_package_json_exclude_newer_drops_versions(server, clear_projects_cache):
+    """Test upstream's version list is dropped once files have been excluded."""
+    exclude_newer_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
+    )
+    with exclude_newer_patch:
+        with set_mock_index_response_is_json(_ResponseType.json):
+            response = requests.get(
+                f"{server}/index/proxpi/",
+                headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+                timeout=5,
+            )
+    assert response.status_code == 200
+    assert "versions" not in response.json()
+
+
+def test_package_html_exclude_newer_unknown(server, clear_projects_cache):
+    """Test excluding files by upload time with the HTML API (all unknown)."""
+    exclude_newer_patch = mock.patch.object(
+        proxpi_server._cache, "EXCLUDE_NEWER", datetime.timedelta(days=365)
+    )
+    with exclude_newer_patch:
+        with set_mock_index_response_is_json(_ResponseType.html):
+            response = requests.get(f"{server}/index/proxpi/", timeout=5)
+    assert response.status_code == 200
+    parser = _utils.IndexParser.from_text(response.text)
+    assert not parser.anchors
 
 
 def test_package_unknown_accept(server):


### PR DESCRIPTION
Adds a PROXPI_EXCLUDE_NEWER setting (seconds) that holds back recently-uploaded files from being served. Basically a quarantine window, for anyone who wants a buffer against brand-new releases before trusting them. PROXPI_EXCLUDE_NEWER_UNKNOWN controls what happens to files with no known upload time, defaults to excluding them. That matters more for the HTML API though, since it never reports upload times at all, so everything served through it counts as "unknown" right now.

Also stopped passing through upstream's versions list as-is once files for a project get filtered out. You could end up with a version listed that had zero files left after exclusion, and that'd throw off resolvers that use the field as a shortcut.

Added tests for the exclusion logic, unit plus a couple through the mock index. README's got the new env vars documented too.

Issue: #110 
